### PR TITLE
import just the useSpring hook from react-use

### DIFF
--- a/src/history.js
+++ b/src/history.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { getSlides } from "./differ";
-import { useSpring } from "react-use";
+import useSpring from "react-use/lib/useSpring";
 import Slide from "./slide";
 import "./comment-box.css";
 


### PR DESCRIPTION
The total bundle size can be reduced (about 10KB) by just importing useSpring instead of whole react-use.