### PR TITLE
Enable mobile gesture support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "react": "^16.8.1",
     "react-dom": "^16.8.1",
     "react-scripts": "2.1.3",
+    "react-swipeable": "^4.3.2",
     "react-use": "^5.2.2"
   },
   "scripts": {

--- a/src/history.js
+++ b/src/history.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { getSlides } from "./differ";
 import useSpring from "react-use/lib/useSpring";
+import Swipeable from "react-swipeable"
 import Slide from "./slide";
 import "./comment-box.css";
 
@@ -109,7 +110,12 @@ export default function History({ commits, language }) {
         currentIndex={current}
         selectCommit={index => setTarget(index)}
       />
-      <Slide time={current - index} lines={slideLines[index]} />
+      <Swipeable
+        onSwipedLeft={nextSlide}
+        onSwipedRight={prevSlide}
+      >
+        <Slide time={current - index} lines={slideLines[index]} />
+      </Swipeable>
     </React.Fragment>
   );
 }


### PR DESCRIPTION
Swiping across code viewport navigates through history. Should address #37 .

May consider wrapping `<CommitList>` as well. From an intuition standpoint it may make sense, but IMHO code window is more usable/accessble [from thumb]. 🤷‍♂️ 